### PR TITLE
eliminar definicion de argumentos por defecto

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,9 +6,6 @@ Organization: UNIR
 import os
 import sys
 
-DEFAULT_FILENAME = "words.txt"
-DEFAULT_DUPLICATES = False
-
 
 def sort_list(items, ascending=True):
     if not isinstance(items, list):
@@ -22,8 +19,6 @@ def remove_duplicates_from_list(items):
 
 
 if __name__ == "__main__":
-    filename = DEFAULT_FILENAME
-    remove_duplicates = DEFAULT_DUPLICATES
     if len(sys.argv) == 3:
         filename = sys.argv[1]
         remove_duplicates = sys.argv[2].lower() == "yes"
@@ -41,7 +36,7 @@ if __name__ == "__main__":
                 word_list.append(line.strip())
     else:
         print(f"El fichero {filename} no existe")
-        word_list = ["ravenclaw", "gryffindor", "slytherin", "hufflepuff"]
+        sys.exit(1)
 
     if remove_duplicates:
         word_list = remove_duplicates_from_list(word_list)


### PR DESCRIPTION
Se eliminan las variables `DEFAULT_FILENAME` y `DEFAULT_DUPLICATES` y en lugar de utilizar valores _dummy_ por defecto, el programa finaliza con error en caso de no recibir argumentos de entrada.