### PR TITLE
añadir listados de ficheros de prueba y script de generacion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,6 @@
 
 run:
 	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py words.txt yes
+
+generate:
+	python ./test/scripts/generate_wordlists.py ./test/wordlists

--- a/test/scripts/generate_wordlists.py
+++ b/test/scripts/generate_wordlists.py
@@ -1,0 +1,52 @@
+import os
+import requests
+import random
+import sys
+import time
+
+TOTAL_COUNT_RANGE = (100, 200)
+DUPLICATES_PERCENTAGE_RANGE = (15, 30)
+
+def get_words(max_words=500):
+    api_url = f"https://api.datamuse.com/words?ml=technology&max={max_words}"
+    response = requests.get(api_url)
+    
+    if response.status_code != 200:
+        raise Exception("Failed to fetch words from Datamuse API")
+    
+    words = [item['word'] for item in response.json()]
+    return words
+
+def generate_wordlist(file_path):
+    words = get_words(500)
+
+    total_count = random.randint(*TOTAL_COUNT_RANGE)
+
+    duplicates_percentage = random.randint(*DUPLICATES_PERCENTAGE_RANGE) / 100.0
+    duplicates_count = total_count - int(total_count * duplicates_percentage)
+
+    selected_words = random.sample(words, total_count)
+    unique_words = selected_words[:total_count - duplicates_count]
+    duplicate_words = random.choices(unique_words, k=duplicates_count)
+
+    word_list = unique_words + duplicate_words
+    random.shuffle(word_list)
+
+    with open(file_path, "w") as file:
+        for word in word_list:
+            file.write(word + "\n")
+
+def main(path):
+    epoch_time = int(time.time())
+
+    for i in range(5):
+        file_name = f"{epoch_time}-{i}.txt"
+        file_path = os.path.join(path, file_name)
+
+        generate_wordlist(file_path)
+
+        print(f"Generated file: {file_path}")
+
+if __name__ == "__main__":
+    path = sys.argv[1]
+    main(path)

--- a/test/wordlists/1712411882-0.txt
+++ b/test/wordlists/1712411882-0.txt
@@ -1,0 +1,104 @@
+edtech
+public eye
+moderne
+technique
+pencil in
+specialism
+innovation
+innovation
+public eye
+catechetics
+pedagogics
+edge
+flesh out
+cmt
+edtech
+moderne
+pedagogics
+compile
+advancement
+pedagogics
+english
+innovation
+english
+pencil in
+economy of scale
+economy of scale
+specialism
+digital
+scholarship
+edge
+innovation
+public eye
+moderne
+economy of scale
+gap
+pencil in
+cmt
+gap
+digital
+act up
+avionic
+avionic
+public eye
+futurology
+pedagogics
+edtech
+scholarship
+specialism
+edtech
+pedagogics
+moderne
+eras
+digital
+futurology
+compile
+act up
+catechetics
+public eye
+futurology
+edge
+technique
+public eye
+innovation
+futurology
+flesh out
+catechetics
+edtech
+avionic
+moderne
+futurology
+specialism
+cmt
+cmt
+public eye
+specialism
+edtech
+technique
+compile
+flesh out
+pencil in
+pencil in
+technique
+advancement
+english
+eras
+flesh out
+advancement
+economy of scale
+technique
+digital
+pencil in
+public eye
+compile
+public eye
+english
+flesh out
+act up
+digital
+compile
+edtech
+scholarship
+technique
+digital
+specialism

--- a/test/wordlists/1712411882-1.txt
+++ b/test/wordlists/1712411882-1.txt
@@ -1,0 +1,115 @@
+nanotechnology
+t level
+in order
+zero in
+stick together
+geog
+zero in
+literacy
+humanity
+work
+mri
+t level
+back up
+tip
+selling point
+stick together
+technologie
+stick together
+humanity
+humanity
+japan
+nrc
+geog
+socio
+ground control
+back up
+techs
+japan
+nanotechnology
+japan
+inst
+work
+technologie
+stick together
+nrc
+technologically
+in order
+in order
+work
+techniques
+ground control
+selling point
+mri
+geog
+humanity
+bioinformatics
+stick together
+japan
+back up
+tip
+tip
+mri
+geog
+in order
+japan
+technologie
+ground control
+selling point
+tip
+technologically
+zero in
+information
+stick together
+selling point
+bundle
+inst
+japan
+inst
+techs
+delft
+tip
+literacy
+delft
+work
+zero in
+bundle
+bioinformatics
+geog
+techs
+back up
+japan
+literacy
+techs
+selling point
+selling point
+bioinformatics
+work
+geog
+inst
+bundle
+nanotechnology
+geog
+bundle
+literacy
+zero in
+techniques
+socio
+nrc
+t level
+geog
+humanity
+t level
+information
+back up
+techs
+technologie
+techs
+techs
+work
+back up
+selling point
+nrc
+techniques
+zero in
+nrc

--- a/test/wordlists/1712411882-2.txt
+++ b/test/wordlists/1712411882-2.txt
@@ -1,0 +1,103 @@
+aerospace
+forensics
+orphan
+forensics
+cyber
+class
+english
+headlines
+backward
+headlines
+advancement
+powered
+compile
+infancy
+class
+going rate
+disclosure
+literacy
+tick
+english
+red ink
+cyberphobia
+disclosure
+powered
+cyberphobia
+class
+e-course
+cyberphobia
+backward
+institute
+infancy
+headlines
+infancy
+e-course
+forensics
+advancement
+cyberphobia
+advancement
+e-course
+cyberphobia
+cyber
+powered
+literacy
+compile
+institute
+compile
+specialism
+long tail
+microarray
+microarray
+advancement
+disclosure
+infancy
+red ink
+long tail
+english
+going rate
+cyberphobia
+institute
+long tail
+backward
+cyberphobia
+cyber
+powered
+red ink
+aerospace
+red ink
+cyberphobia
+e-course
+microarray
+disclosure
+specialism
+orphan
+specialism
+disclosure
+literacy
+literacy
+cyber
+specialism
+maglev
+going rate
+compile
+powered
+disclosure
+microarray
+techno
+aerospace
+microarray
+orphan
+backward
+tick
+red ink
+red ink
+specialism
+orphan
+cyberphobia
+maglev
+english
+institute
+advancement
+advancement
+red ink
+english

--- a/test/wordlists/1712411882-3.txt
+++ b/test/wordlists/1712411882-3.txt
@@ -1,0 +1,128 @@
+intel
+grammatology
+sea change
+psychology
+tip
+information technology (it)
+french
+bicmos
+tip
+act up
+information technology (it)
+grammar
+innovation
+e-marking
+information warfare
+electronics
+archaeology
+information warfare
+master of science
+sea change
+industry
+innovation
+fall over
+grammar
+sea change
+nrc
+nrc
+fall over
+industry
+master of science
+japan
+cmt
+tell
+tip
+big boys
+e-marking
+cryogenics
+techne
+archaeology
+vpro
+japan
+industry
+industry
+grammar
+tip
+institute
+big boys
+gap
+cmt
+metallurgy
+tip
+fall over
+vpro
+tip
+innovation
+sea change
+cryogenics
+psychology
+electronics
+industry
+act up
+bicmos
+call up
+tip
+techne
+nrc
+sea change
+psychology
+grammar
+tell
+french
+metallurgy
+master of science
+e-marking
+psychology
+cmt
+fall over
+techne
+techne
+grammar
+industry
+grammatology
+metallurgy
+innovation
+institute
+metallurgy
+call up
+opposite number
+information warfare
+master of science
+cryogenics
+act up
+information technology (it)
+intel
+cmt
+information technology (it)
+french
+cmt
+industry
+televersity
+techne
+sea change
+psychology
+call up
+industry
+tip
+innovation
+act up
+televersity
+call up
+gap
+information warfare
+nrc
+japan
+sea change
+metallurgy
+archaeology
+tip
+industry
+electronics
+archaeology
+call up
+industry
+gap
+opposite number
+cryogenics
+industry
+televersity

--- a/test/wordlists/1712411882-4.txt
+++ b/test/wordlists/1712411882-4.txt
@@ -1,0 +1,170 @@
+parties
+dialect
+shape up
+metallurgy
+socio
+parties
+catalyze
+shape up
+vernacular
+parties
+ahead
+geog
+geog
+hi-tech
+game plan
+metallurgy
+gap
+arts
+advances
+technikon
+technikon
+wireless network
+socio
+humanism
+humanity
+computing
+ahead
+nanotechnology
+dialect
+luddite
+shape up
+delft
+cyberphobia
+metallurgy
+catalyze
+humanism
+take form
+game plan
+subliterature
+electricity
+nanotechnology
+luddite
+vernacular
+space
+equipment
+ssl
+vernacular
+gap
+advances
+biodata
+treatise
+advances
+expertise
+advances
+polytech
+subliterature
+ahead
+cryogenics
+humanity
+cyberphobia
+biodata
+ahead
+nanotechnology
+game plan
+parties
+shape up
+ahead
+wireless network
+luddite
+luddite
+cryogenics
+equipment
+delft
+big boys
+subliterature
+national technical information service
+geog
+cryogenics
+parties
+equipment
+arts
+equipment
+treatise
+luddite
+metallurgy
+nucleonics
+equipment
+delft
+geog
+nucleonics
+polytech
+advances
+catalyze
+arts
+humanism
+geog
+ahead
+nucleonics
+geog
+big boys
+electricity
+dialect
+take form
+subliterature
+treatise
+ahead
+arts
+expertise
+nucleonics
+nucleonics
+arts
+space
+national technical information service
+nucleonics
+humanity
+biodata
+vernacular
+wireless network
+equipment
+humanity
+treatise
+vernacular
+space
+dialect
+polytech
+treatise
+socio
+space
+vernacular
+national technical information service
+hi-tech
+dance
+dance
+treatise
+ahead
+catalyze
+computing
+subliterature
+arts
+dialect
+expertise
+subliterature
+hi-tech
+vernacular
+take form
+gap
+metallurgy
+wordbook
+parties
+dance
+wordbook
+equipment
+big boys
+vernacular
+ssl
+socio
+vernacular
+nucleonics
+gap
+expertise
+nucleonics
+parties
+expertise
+subliterature
+expertise
+arts
+cryogenics
+hi-tech
+humanity
+subliterature


### PR DESCRIPTION
Se crea un _script_ para generar ficheros con listados de palabras y duplicados, obtenidas desde una API pública. Se añade un _target_ al fichero `Makefile` para ejecutar este _script_ y se incluyen varios ficheros de prueba pregenerados.