### PR TITLE
makefile: esqueleto, ejecucion sin contenedor y targets de testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,33 @@
+.POSIX:
+.SILENT:
+
 .PHONY: all $(MAKECMDGOALS)
 
-run:
-	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py words.txt yes
+SORT ?= no
+
+.check_defined:
+ifndef FILE
+	echo "FILE variable is not defined"
+	exit 1
+endif
+
+run: .check_defined
+	python main.py $(FILE) $(SORT)
+
+run_container: .check_defined
+	docker run --rm -v $(PWD):/opt/app -w /opt/app -e PYTHON_PATH=/opt/app \
+		docker.io/library/python:3.6-slim \
+		python main.py $(FILE) $(SORT)
+
+test:
+	find . \
+		-wholename "./test/wordlists/*.txt" \
+		-exec $(MAKE) run FILE={} \;
+
+test_container:
+	find . \
+		-wholename "./test/wordlists/*.txt" \
+		-exec $(MAKE) run_container FILE={} \;
 
 generate:
 	python ./test/scripts/generate_wordlists.py ./test/wordlists


### PR DESCRIPTION
El resultado final incluye reglas para la ejecución de la aplicación de forma nativa y a través de un contenedor. Además, se incluyen dos reglas adicionales para hacer _tests_ con los fichero de prueba que ha incluido @xcnrunir-3 en #3, pendiente de mergear.